### PR TITLE
fix: alias `near-api-js` to unminified version

### DIFF
--- a/getting-started-vite/vite.config.js
+++ b/getting-started-vite/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
       assert: 'assert',
       crypto: 'crypto-browserify',
       util: 'util',
+      'near-api-js': 'near-api-js/dist/near-api-js.js',
     },
   },
   define: {


### PR DESCRIPTION
vite is not compatible with the near js sdk
this is a temporary workaround until https://github.com/near/near-api-js/issues/1013 is fixed
fixes #29 