### PR TITLE
Remove Phantom wallet adapter

### DIFF
--- a/mint-ui-example/pages/index.js
+++ b/mint-ui-example/pages/index.js
@@ -7,7 +7,6 @@ import {
 import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
 import {
   GlowWalletAdapter,
-  PhantomWalletAdapter,
   SlopeWalletAdapter,
   SolflareWalletAdapter,
   TorusWalletAdapter,
@@ -29,7 +28,6 @@ export default function Home() {
 
   const wallets = useMemo(
     () => [
-      new PhantomWalletAdapter(),
       new GlowWalletAdapter(),
       new SlopeWalletAdapter(),
       new SolflareWalletAdapter({ network }),


### PR DESCRIPTION
Since Phantom is now using the standard wallet adapter the special adapter is not required anymore.
In contrast there where even issues reqported related to signature verification and Phantom using the old adapter.