### PR TITLE
remove constructor for glow and slope

### DIFF
--- a/mint-ui-example/pages/index.js
+++ b/mint-ui-example/pages/index.js
@@ -30,8 +30,6 @@ export default function Home() {
   const wallets = useMemo(
     () => [
       new PhantomWalletAdapter(),
-      new GlowWalletAdapter(),
-      new SlopeWalletAdapter(),
       new SolflareWalletAdapter({ network }),
       new TorusWalletAdapter(),
     ],


### PR DESCRIPTION
The example in ` mint-ui-example/pages/index.js` is not following the updated wallet standard which removes the need to write constructor for Glow and Slope Wallet Adapter